### PR TITLE
fix: add python bin to path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -189,6 +189,25 @@ runs:
       run: |
         set +e
 
+        # Add Python bin directory to PATH to ensure installed scripts are available
+        PYTHON_BIN_DIR="$(python3 -c 'import sys; import os; print(os.path.dirname(sys.executable))' 2>&1)"
+        if [[ $? -ne 0 ]] || [[ -z "$PYTHON_BIN_DIR" ]]; then
+          echo "::error::Failed to determine Python bin directory"
+          echo "::error::Python detection output: $PYTHON_BIN_DIR"
+          exit 1
+        fi
+
+        export PATH="$PYTHON_BIN_DIR:$PATH"
+
+        # Verify insomnia-run is available
+        if ! command -v insomnia-run &> /dev/null; then
+          echo "::error::insomnia-run command not found after installation"
+          echo "::error::Python bin directory: $PYTHON_BIN_DIR"
+          echo "::error::Current PATH: $PATH"
+          echo "::error::This may indicate an installation issue. Please report this at https://github.com/scarowar/insomnia-run/issues"
+          exit 1
+        fi
+
         if [[ "$COMMAND" != "collection" && "$COMMAND" != "test" ]]; then
           echo "::error::Invalid command '$COMMAND'. Must be 'collection' or 'test'."
           exit 1


### PR DESCRIPTION
# Pull Request

Thank you for your contribution! Please review the checklist below before submitting your pull request.

## Checklist

- [x] My pull request addresses a single issue or concern
- [x] I have described the changes clearly
- [x] I have run all pre-commit checks (`pre-commit run --all-files`)
- [x] I have updated documentation as needed (e.g., `README.md`)
- [x] I have tested the changes (if applicable)
- [x] I have checked for breaking changes

## Description

1. Detects Python's bin directory dynamically
    1. Works with: system Python, pyenv, venv, conda, any installation
    2. Uses sys.executable which is the standard Python way
2. Error handling
    1. ✅ Checks if Python command succeeds ($?)
    2. ✅ Checks if output is not empty
    3. ✅ Captures both stdout and stderr with 2>&1
    4. ✅ Provides clear error messages with actual output
3. Updates PATH
    1. Prepends Python bin directory to PATH
    2. Ensures insomnia-run command is available
4. Verification
    4. Explicitly checks if insomnia-run command exists
    5. Fails fast with detailed debugging info if not found

## Related Issues

<!-- List any related issues, e.g., "Closes #123" -->
